### PR TITLE
Restore verify panel, clean dead config, fix /freeze crash, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,211 @@
-Staff Utils is a simple but effective plugin that does its job.
+# KushStaffUtils
 
-Kush Staff Utils currently has a few features including
+A configurable staff-utility and Discord-integration plugin for Spigot/Paper servers. It bridges
+your Minecraft server and a Discord bot/webhooks — logging, moderation tools, account syncing, and
+timed rewards — all driven by config.
 
-Spigot Page: https://www.spigotmc.org/resources/kushstaffutils-1-8-1-19-fully-configurable.107607
+> Made by **Exotic Development** · Author: **DankOfUK**
 
-Exotic Development: http://discord.gg/2xYgHUfubM
+- Spigot: https://www.spigotmc.org/resources/kushstaffutils-1-8-1-19-fully-configurable.107607
+- Discord: http://discord.gg/2xYgHUfubM
 
-Discord: DankOfUK
+---
+
+## Compatibility
+
+| | |
+|---|---|
+| **Minecraft** | Spigot / Paper / Purpur **1.8 → 1.21.x** (single jar) |
+| **Java** | Compiled to **Java 8** bytecode (runs on legacy and modern servers) |
+| **Optional hooks** | PlaceholderAPI, Vault, LiteBans, AdvancedBan, InteractiveChat, AntiCheatReplay |
+
+Version-specific API (e.g. renamed potion effects) is resolved at runtime, so the same jar works
+across the whole range. `api-version` is intentionally left out of `plugin.yml` to preserve 1.8
+loading.
+
+---
+
+## Features
+
+**Moderation**
+- **Freeze** — freezes a player (blindness + slowness, movement lock, freeze GUI, block/chat/command
+  restrictions), auto-punish on logout.
+- **Player reports** (`/report`) — sends reports to Discord.
+- **Faction strikes** (`/strike`) — strike a group/island/faction.
+- **Bug reports** (`/bug`) and **suggestions** (`/suggestion`) posted to Discord.
+
+**Logging**
+- **Per-user command logging** to files, viewable in-game (`/viewlogs`) with clickable pagination.
+- **Command logger** — logs player commands to Discord (with ignore/whitelist lists).
+- **Chat webhook** — mirrors in-game chat to a Discord webhook.
+- **Join/Leave logger** — posts join/leave messages to a webhook (PlaceholderAPI-aware).
+- **Creative logging** — logs item drops and creative middle-click grabs.
+- **Ban-plugin logging** — pushes **LiteBans** and **AdvancedBan** ban/tempban/ipban/mute/warn/kick
+  events to Discord webhooks.
+- **Start/Stop logger** — announces server start/shutdown in Discord.
+- **Factions Top announcer** — periodic FTop announcements.
+
+**Discord bot** (JDA)
+- Slash commands (see below), a Discord→game chat bridge, and server-control from Discord.
+
+**Account Sync** *(new)* — link a Discord account to a Minecraft account via a one-time code, granting
+Discord roles and running in-game commands. See [Account Sync](#account-sync).
+
+**Timed Rewards** *(new)* — the bot posts a reward panel with claim buttons; synced players claim
+in-game rewards on a per-reward cooldown. See [Timed Rewards](#timed-rewards).
+
+---
+
+## In-game commands & permissions
+
+| Command | Description | Permission |
+|---|---|---|
+| `/stafflogger reload` | Reload the plugin config | `commandlogger.reload` |
+| `/viewlogs <player> [page]` | View a player's logged commands | `commandlogger.viewlogs.use` |
+| `/freeze <player>` | Freeze / unfreeze a player | `commandlogger.freeze.use` |
+| `/report <player> <reason>` | Report a player to Discord | `commandlogger.report.use` |
+| `/strike ...` (alias `/strikes`) | Strike a group/island/faction | `commandlogger.strike.use` |
+| `/bug <message>` | Report a bug to Discord | `commandlogger.bug.use` |
+| `/suggestion <text>` (alias `/suggest`) | Submit a suggestion | `commandlogger.suggest.use` |
+| `/sync <code>` | Link your account with a Discord code | *(none — any player)* |
+
+**Passive permission nodes**
+- `commandlogger.log` — this player's commands are logged to Discord.
+- `commandlogger.bypass` — exclude this player from command logging.
+- `commandlogger.creative-logging.log` — this player's creative drops/grabs are logged.
+
+---
+
+## Discord slash commands
+
+Registered **per-guild** (available instantly). Admin-only commands require the role in
+`bot.adminRoleID`, or Discord **Administrator** permission if that's unset.
+
+| Command | Description | Admin |
+|---|---|---|
+| `/help` | List the bot's commands | |
+| `/online` | List online players | |
+| `/serverinfo` | Server/guild info | |
+| `/ftop` | Post FTop data | |
+| `/logs <user>` | Fetch a player's logs | |
+| `/avatar <user>` | Show a user's avatar | |
+| `/command <command>` | Run a console command on the server | ✅ |
+| `/sendsyncpanel <channel>` | Post the account-sync panel | ✅ |
+| `/sendrewardpanel <channel>` | Post the reward panel | ✅ |
+| `/unsync <user>` | Remove a user's account link | ✅ |
+
+---
+
+## Account Sync
+
+**Flow**
+1. An admin runs `/sendsyncpanel #channel` → the bot posts an embed with a button.
+2. A user clicks the button → receives a one-time code (valid for `CODE-EXPIRY-MINUTES`).
+3. In-game they run `/sync <code>` → their accounts are linked, they receive the configured Discord
+   roles, and the configured in-game commands run.
+4. `/unsync <user>` (admin) removes the link and strips the sync roles.
+
+**Config** (`syncing.yml`)
+```yaml
+SYNC-PANEL:
+  ROLE-GIVEN-ON-SYNC:        # Discord role IDs granted on sync
+    - "111111111111111111"
+  EMBED-MESSAGE:             # panel embed body (one entry per line)
+    - "Kush Rewards - Syncing Panel"
+    - "Click to start the sync process!"
+  THUMBNAIL-URL: "https://example.com/image.png"
+  BUTTON-MESSAGE: "Click here!"
+  SENT-MESSAGE: "Sync Panel sent to %channel%"
+  INVALID-CHANNEL-MESSAGE: "Invalid Channel!"
+  CODE-EXPIRY-MINUTES: 5     # how long a code stays valid
+  COMMANDS-ON-SYNC:          # console commands run on sync (%player%, %uuid%)
+    - "lp user %player% parent addtemp synced 30d"
+
+MESSAGES:                    # in-game /sync messages (support & and &#RRGGBB colors)
+  COMMAND-USAGE: "&cUse /sync <code>!"
+  INVALID-CODE-MESSAGE: "&cYour code is invalid or expired!"
+  ALREADY-SYNCED-MESSAGE: "&cYou have already been synced!"
+  SYNCED-SUCCESSFULLY-MESSAGE: "&aYou have been successfully synced!"
+```
+
+---
+
+## Timed Rewards
+
+**Flow**
+1. The bot posts the reward panel (auto every `POST-INTERVAL` minutes if `AUTO-POST: true`, or on
+   demand via `/sendrewardpanel #channel`) with one claim button per entry in `BUTTONS`.
+2. A user clicks a reward button. The plugin checks: **synced → has the required role → online
+   in-game → off cooldown**, then runs that reward's commands.
+3. Each reward can be claimed once per its `REWARD-INTERVAL` (**seconds**).
+
+**Config** (`syncing.yml`)
+```yaml
+REWARD-PANEL:
+  CHANNEL-ID: "123456789012345678"   # channel for the auto-post
+  POST-INTERVAL: 30                  # minutes between auto-posts
+  AUTO-POST: false                   # enable the recurring auto-post
+
+REWARD-EMBED:
+  TITLE: "Rewards"
+  DESCRIPTION:
+    - "Claim your rewards below!"
+  THUMBNAIL-URL: "https://example.com/image.png"
+  COLOR: "#FFA500"
+
+BUTTONS:
+  button1:
+    REQUIRED-ROLE-ID: "111111111111111111"  # role required to claim
+    REWARDS:                                 # console commands (%player%, %uuid%)
+      - "give %player% diamond 5"
+    REWARD-INTERVAL: 120                     # cooldown in SECONDS
+    MESSAGE: "Claim Diamonds"                # button label
+```
+
+> Rewards require the player to be **online** (so item commands succeed) and **synced** (so the bot
+> knows which player to reward).
+
+---
+
+## Configuration files
+
+| File | Purpose |
+|---|---|
+| `config.yml` | Main config — feature toggles, bot settings, webhooks, messages |
+| `messages.yml` | Reload / no-permission messages |
+| `discord-bot.yml` | Bot-only settings (e.g. FTop command role) |
+| `syncing.yml` | Account-sync and reward settings |
+| `data.yml` | *(auto-generated)* account links + reward cooldowns |
+
+Key `config.yml` settings for Discord features: `bot.enabled`, `bot.discord_token`,
+`bot.adminRoleID`. Reload most settings with `/stafflogger reload`.
+
+> Note: the `MYSQL` and `SYNC-RANKS` sections in `syncing.yml` are unused — storage is the
+> flat-file `data.yml`.
+
+---
+
+## Soft dependencies
+
+`PlaceholderAPI`, `Vault`, `LiteBans`, `AdvancedBan`, `InteractiveChat`, `AntiCheatReplay`. All are
+optional; the related features simply stay disabled if the plugin isn't present. (Group placeholders
+for chat logging require a Vault-compatible permissions plugin such as LuckPerms.)
+
+---
+
+## Building
+
+Requires JDK 8+ and Maven. Produces a shaded jar (bundles JDA) targeting Java 8.
+
+```bash
+mvn clean package
+```
+
+Output: `target/KushStaffUtils-<version>.jar`.
+
+---
+
+## Credits
+
+- **Author:** DankOfUK — Exotic Development
+- Built with [JDA](https://github.com/discord-jda/JDA), bStats, and the Spigot/Bukkit API.

--- a/src/main/java/me/dankofuk/commands/FreezeCommand.java
+++ b/src/main/java/me/dankofuk/commands/FreezeCommand.java
@@ -81,11 +81,15 @@ public class FreezeCommand implements CommandExecutor, Listener {
         if (frozenPlayers.containsKey(target)) {
             // Player is already frozen, unfreeze them and remove them from the list of frozen players
             unfreezePlayer(target);
-            sender.sendMessage(String.format(me.dankofuk.utils.ColorUtils.translateColorCodes(unfreezeSuccessMessage), target.getName()));
+            // Use literal placeholder replacement: the config messages contain %player% (not %s),
+            // so String.format would throw UnknownFormatConversionException on the '%p'.
+            sender.sendMessage(me.dankofuk.utils.ColorUtils.translateColorCodes(
+                    unfreezeSuccessMessage.replace("%player%", target.getName())));
         } else {
             // Player is not frozen, freeze them
             freezePlayer(target);
-            sender.sendMessage(String.format(me.dankofuk.utils.ColorUtils.translateColorCodes(freezeSuccessMessage), target.getName()));
+            sender.sendMessage(me.dankofuk.utils.ColorUtils.translateColorCodes(
+                    freezeSuccessMessage.replace("%player%", target.getName())));
         }
         return true;
     }
@@ -98,8 +102,10 @@ public class FreezeCommand implements CommandExecutor, Listener {
         addEffect(player, me.dankofuk.utils.Compat.JUMP_BOOST, -10);
         // Open the frozen GUI
         openFrozenGUI(player);
-        // Send the freeze message to the player
-        player.sendMessage(me.dankofuk.utils.ColorUtils.translateColorCodes(String.valueOf(freezeMessages)));
+        // Send the freeze message to the player (one configured line at a time)
+        for (String line : freezeMessages) {
+            player.sendMessage(me.dankofuk.utils.ColorUtils.translateColorCodes(line));
+        }
         // Start task to check for movement and teleport player back
         BukkitTask task = new BukkitRunnable() {
             final Location previousLocation = player.getLocation();

--- a/src/main/java/me/dankofuk/discord/DiscordBot.java
+++ b/src/main/java/me/dankofuk/discord/DiscordBot.java
@@ -80,6 +80,7 @@ public class DiscordBot extends ListenerAdapter {
         this.jda.addEventListener(new AvatarCommand());
         this.jda.addEventListener(new ServerInfoCommand());
         this.jda.addEventListener(new FTopCommand(this));
+        this.jda.addEventListener(new me.dankofuk.discord.verify.SendVerifyPanel(this, KushStaffUtils.getInstance()));
         this.jda.addEventListener(new me.dankofuk.sync.SyncRewardListener(this));
         //this.jda.addEventListener(new TicketSystem(this));
     }
@@ -103,6 +104,7 @@ public class DiscordBot extends ListenerAdapter {
         commandsData.add(Commands.slash("command", "Sends the command to the server.").addOption(OptionType.STRING, "command", "The command you want to send."));
         commandsData.add(Commands.slash("logs", "Gets the logs for the user you enter.").addOption(OptionType.STRING, "user", "The user you would like the logs for."));
         commandsData.add(Commands.slash("avatar", "Gets the avatar of a user.").addOption(OptionType.USER, "user", "The user that the avatar for."));
+        commandsData.add(Commands.slash("sendverifypanel", "Sends the verify panel to the channel you select").addOption(OptionType.CHANNEL, "channel", "The channel to send the panel to."));
         commandsData.add(Commands.slash("sendsyncpanel", "Sends the sync panel to the channel you select").addOption(OptionType.CHANNEL, "channel", "The channel to send the panel to."));
         commandsData.add(Commands.slash("sendrewardpanel", "Sends the reward panel to the channel you select").addOption(OptionType.CHANNEL, "channel", "The channel to send the panel to."));
         commandsData.add(Commands.slash("unsync", "Unsync a user that has been synced").addOption(OptionType.USER, "user", "User you want to unsync"));
@@ -111,11 +113,17 @@ public class DiscordBot extends ListenerAdapter {
 
     public void onGuildReady(@NotNull GuildReadyEvent event) {
         // Guild-scoped registration: available immediately in this guild.
-        event.getGuild().updateCommands().addCommands(buildCommands()).queue(
-                success -> KushStaffUtils.getInstance().getLogger()
-                        .info("[Discord Bot] Registered " + success.size() + " slash commands in guild " + event.getGuild().getName()),
-                error -> KushStaffUtils.getInstance().getLogger()
-                        .warning("[Discord Bot] Failed to register slash commands: " + error.getMessage()));
+        List<CommandData> commands = buildCommands();
+        event.getGuild().updateCommands().addCommands(commands).queue(
+                success -> KushStaffUtils.getInstance().getLogger().info(
+                        "[Discord Bot] Registered " + success.size() + " slash commands in guild "
+                                + event.getGuild().getName() + ": "
+                                + success.stream().map(net.dv8tion.jda.api.interactions.commands.Command::getName)
+                                        .collect(java.util.stream.Collectors.joining(", "))),
+                error -> KushStaffUtils.getInstance().getLogger().warning(
+                        "[Discord Bot] Failed to register slash commands in "
+                                + event.getGuild().getName() + " (is the bot invited with the "
+                                + "applications.commands scope?): " + error.getMessage()));
     }
 
     public void onReady(@NotNull ReadyEvent event) {

--- a/src/main/java/me/dankofuk/discord/commands/HelpCommand.java
+++ b/src/main/java/me/dankofuk/discord/commands/HelpCommand.java
@@ -25,16 +25,16 @@ public class HelpCommand extends ListenerAdapter {
                 helpEmbed.setDescription("Command List");
 
                 helpEmbed.addField("/help", "Shows this menu", false);
-                helpEmbed.addField("/command [command]", "Sends a command to the server!", true);
-                helpEmbed.addField("/online", "Shows the players online", false);
-                helpEmbed.addField("/sendverifypanel [channel]", "Sends the verify panel the selected channel.", true);
-                helpEmbed.addField("/logs [user]", "Shows the log file for the user selected", true);
+                helpEmbed.addField("/online", "Shows the players online", true);
+                helpEmbed.addField("/serverinfo", "Shows information about this server", true);
+                helpEmbed.addField("/ftop", "Posts the FTop data", true);
+                helpEmbed.addField("/command [command]", "Runs a console command on the server (admin)", true);
+                helpEmbed.addField("/logs [user]", "Shows the log file for the user selected (admin)", true);
                 helpEmbed.addField("/avatar [user]", "Shows the avatar for the user selected", true);
-                helpEmbed.addField("/unsync [user]", "Starts the syncing process!", true);
-                helpEmbed.addField("/sendsyncpanel [channel]", "Sends the sync panel the selected channel.", true);
-                helpEmbed.addField("/createticketpanel", "Sends the ticket panel the current channel.", true);
-                helpEmbed.addField("/sendrewardpanel [channel]", "Sends the reward panel the selected channel.", true);
-                helpEmbed.addField("/reload", "Reloads the configs for the bot related stuff.", false);
+                helpEmbed.addField("/sendverifypanel [channel]", "Sends the verify panel to a channel (admin)", true);
+                helpEmbed.addField("/sendsyncpanel [channel]", "Sends the account-sync panel to a channel (admin)", true);
+                helpEmbed.addField("/sendrewardpanel [channel]", "Sends the reward panel to a channel (admin)", true);
+                helpEmbed.addField("/unsync [user]", "Removes a user's account link (admin)", true);
 
                 helpEmbed.setFooter("Help Page 1/1 - Made by Exotic Development");
                 event.replyEmbeds(helpEmbed.build()).setEphemeral(true).queue();

--- a/src/main/java/me/dankofuk/discord/verify/SendVerifyPanel.java
+++ b/src/main/java/me/dankofuk/discord/verify/SendVerifyPanel.java
@@ -1,0 +1,115 @@
+package me.dankofuk.discord.verify;
+
+import me.dankofuk.KushStaffUtils;
+import me.dankofuk.discord.DiscordBot;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.bukkit.configuration.Configuration;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.Color;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Verify panel: {@code /sendverifypanel <channel>} posts an embed with a button; clicking it grants
+ * a configurable "verified" Discord role. Driven by the {@code verify_panel.*} keys in config.yml.
+ */
+public class SendVerifyPanel extends ListenerAdapter {
+
+    public static final String VERIFY_BUTTON_ID = "verify_button";
+
+    public KushStaffUtils instance;
+    public DiscordBot discordBot;
+
+    public SendVerifyPanel(DiscordBot discordBot, KushStaffUtils instance) {
+        this.discordBot = discordBot;
+        this.instance = instance;
+    }
+
+    private boolean isAdmin(Member member) {
+        if (member == null) {
+            return false;
+        }
+        String adminRoleId = discordBot.getAdminRoleID();
+        if (adminRoleId == null || adminRoleId.isEmpty()) {
+            return member.hasPermission(net.dv8tion.jda.api.Permission.ADMINISTRATOR);
+        }
+        return member.getRoles().stream().anyMatch(role -> role.getId().equals(adminRoleId));
+    }
+
+    @Override
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        // Gate on the command name FIRST so this listener never responds to other commands.
+        if (!event.getName().equals("sendverifypanel")) {
+            return;
+        }
+
+        if (!isAdmin(event.getMember())) {
+            EmbedBuilder noPerms = new EmbedBuilder();
+            noPerms.setColor(Color.RED);
+            noPerms.setTitle("Error #NotDankEnough");
+            noPerms.setDescription(">  `You lack the required permissions for this command!`");
+            noPerms.setFooter(OffsetDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME));
+            event.replyEmbeds(noPerms.build()).setEphemeral(true).queue();
+            return;
+        }
+
+        Configuration config = KushStaffUtils.getInstance().getConfig();
+        OptionMapping channelOption = event.getOption("channel");
+        MessageChannel channel = channelOption == null ? null
+                : discordBot.getJda().getChannelById(MessageChannel.class, channelOption.getAsString());
+
+        if (channel == null) {
+            event.reply("Invalid channel.").setEphemeral(true).queue();
+            return;
+        }
+
+        List<String> embedMessageList = config.getStringList("verify_panel.embedMessage");
+        String embedMessage = embedMessageList.isEmpty()
+                ? "Click below to verify!" : String.join("\n", embedMessageList);
+        String buttonMessage = config.getString("verify_panel.buttonMessage", "Verify");
+        String sentMessage = config.getString("verify_panel.sentMessage", "Verify panel sent!");
+
+        channel.sendMessage(embedMessage)
+                .setActionRow(Button.primary(VERIFY_BUTTON_ID, buttonMessage))
+                .queue();
+        event.reply(sentMessage).setEphemeral(true).queue();
+    }
+
+    @Override
+    public void onButtonInteraction(@NotNull ButtonInteractionEvent event) {
+        if (!event.getComponentId().equals(VERIFY_BUTTON_ID)) {
+            return;
+        }
+        Guild guild = event.getGuild();
+        if (guild == null) {
+            event.reply("This can only be used in a server.").setEphemeral(true).queue();
+            return;
+        }
+        Configuration config = KushStaffUtils.getInstance().getConfig();
+        String roleId = config.getString("verify_panel.giveRoleOnClicks");
+        Role role = roleId == null ? null : guild.getRoleById(roleId);
+        if (role == null) {
+            event.reply("Verify role not found (tell an administrator).").setEphemeral(true).queue();
+            return;
+        }
+        guild.addRoleToMember(UserSnowflake.fromId(event.getUser().getId()), role)
+                .reason("KushStaffUtils verify panel")
+                .queue(
+                        success -> event.reply(config.getString("verify_panel.roleGivenMessage",
+                                "You have been verified!")).setEphemeral(true).queue(),
+                        error -> event.reply("Could not give the verify role: " + error.getMessage())
+                                .setEphemeral(true).queue());
+    }
+}

--- a/src/main/java/me/dankofuk/discord/verify/SendVerifyPanel.java
+++ b/src/main/java/me/dankofuk/discord/verify/SendVerifyPanel.java
@@ -81,7 +81,15 @@ public class SendVerifyPanel extends ListenerAdapter {
         String buttonMessage = config.getString("verify_panel.buttonMessage", "Verify");
         String sentMessage = config.getString("verify_panel.sentMessage", "Verify panel sent!");
 
-        channel.sendMessage(embedMessage)
+        EmbedBuilder panel = new EmbedBuilder();
+        panel.setDescription(embedMessage);
+        panel.setColor(new Color(88, 101, 242)); // blurple
+        String thumb = config.getString("verify_panel.embedThumbnail");
+        if (thumb != null && thumb.startsWith("http")) { // ignore the "link-here" placeholder
+            panel.setThumbnail(thumb);
+        }
+
+        channel.sendMessageEmbeds(panel.build())
                 .setActionRow(Button.primary(VERIFY_BUTTON_ID, buttonMessage))
                 .queue();
         event.reply(sentMessage).setEphemeral(true).queue();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -450,14 +450,3 @@ advancedbans:
     embedFooter: "%time%"
     embedThumbnail: "https://cdn.discordapp.com/avatars/1093413225338507344/a60fa5f0a630cafb471effcf3a3e1bd8.png?size=4096"
     embedAvatar: "https://cdn.discordapp.com/avatars/1093413225338507344/a60fa5f0a630cafb471effcf3a3e1bd8.png?size=4096"
-
-#----------------------------------------------------------------
-# Ticket System Configuration - Discord Required
-#----------------------------------------------------------------
-# Placeholders for Ticket Systen
-#
-
-TICKET_CHANNELS:
-  SUPPORT: "channel_id_for_support"
-  REPORT: "channel_id_for_report"
-  FEEDBACK: "channel_id_for_feedback"

--- a/src/main/resources/syncing.yml
+++ b/src/main/resources/syncing.yml
@@ -21,12 +21,8 @@ SYNC-PANEL:
   # Console commands run in-game when a player successfully syncs. %player% / %uuid% are replaced.
   COMMANDS-ON-SYNC:
     - "lp user %player% parent addtemp synced 30d"
-  # Sent (ephemeral) after /sendsyncpanel. %channel% is replaced with the channel mention.
-  SENT-MESSAGE-CONFIRM: "Sync Panel sent to %channel%"
 
   INVALID-CHANNEL-MESSAGE: "Invalid Channel!"
-  ROLE-GIVEN-MESSAGE: "Your roles have been given for syncing successfully!"
-  ROLE-NOT-FOUND-MESSAGE: "No roles have been found (tell your administrator)"
 
 # Messages
 MESSAGES:
@@ -56,16 +52,6 @@ REWARD-EMBED:
   THUMBNAIL-URL: "https://i.ytimg.com/vi/mm8UEsfVAUE/maxresdefault.jpg"
   COLOR: "#FFA500"
 
-SYNC-RANKS:
-  rank1:
-    ROLE-ID-GIVEN: "discord-role1"
-    LUCK-PERMS-RANK: "rank1"
-    BUTTON-ID: "button1"
-  rank2:
-    ROLE-ID-GIVEN: "discord-role2"
-    LUCK-PERMS-RANK: "rank2"
-    BUTTON-ID: "button2"
-
 BUTTONS:
   button1:
     REQUIRED-ROLE-ID: "961839666556960792"
@@ -91,8 +77,3 @@ BUTTONS:
       - "give %player% coal 10"
     REWARD-INTERVAL: 60
     MESSAGE: "Claim Coal"
-
-MYSQL:
-  URL: "jdbc:mysql:"
-  USERNAME: "username"
-  PASSWORD: "password"


### PR DESCRIPTION
## Overview
Follow-up changes on top of the merged PR #26. Restores the verify panel, cleans dead config, fixes a `/freeze` crash, and adds full docs. Verified with `mvn package` (Java 8 bytecode, shaded jar) and tested on Purpur 26.1.2.

## Changes
- **Restore `/sendverifypanel`** — the handler was deleted in old "removed verify stuff" commits while the command registration was left behind. Recovered `SendVerifyPanel` from history, re-registered the command + button listener, and fixed a real bug where its permission check ran for *every* slash command (it now gates on the command name first). Hardened null cases and made the panel a proper embed that uses `verify_panel.embedThumbnail`.
- **Remove dead config** — audited every config key against the code and dropped orphaned entries: `TICKET_CHANNELS` (config.yml), plus `SYNC-RANKS`, `MYSQL`, and unused `SENT-MESSAGE-CONFIRM` / `ROLE-GIVEN-MESSAGE` / `ROLE-NOT-FOUND-MESSAGE` (syncing.yml).
- **Fix `/freeze` crash** — it called `String.format` on messages containing `%player%`, throwing `UnknownFormatConversionException` on `%p`. Switched to literal `%player%` replacement. Also fixed `freezePlayer` sending the freeze messages as one bracketed list instead of line-by-line.
- **Rewrite README** — full feature list, in-game commands with accurate permission nodes, Discord slash commands, account-sync and reward config examples, and 1.8–1.21.x compatibility notes.

## Reviewer notes
- No new dependencies; storage remains flat-file (`data.yml`).
- `verify_panel.*` keys already existed in config.yml; only the handler was missing.

Generated with [Claude Code](https://claude.com/claude-code)